### PR TITLE
Support functions: sizeof

### DIFF
--- a/docs/functions.tsv
+++ b/docs/functions.tsv
@@ -1,0 +1,2 @@
+Name	Summary
+SIZEOF	The size of the structure in bytes

--- a/src/constants/assembly.ts
+++ b/src/constants/assembly.ts
@@ -107,3 +107,6 @@ export const constantPseudoOps = new Set([
   '.str', '.strz', '.strs',
 ]);
 
+export const operandFunctions = new Set([
+  'sizeof',
+]);

--- a/src/parsers/line-parser.ts
+++ b/src/parsers/line-parser.ts
@@ -1,6 +1,7 @@
 import {
   delimitedStringPseudoOps,
   filePseudoOps,
+  operandFunctions,
   operandOpcodes,
   pragmaPseudoOps,
   registers,
@@ -317,7 +318,11 @@ export class LineParser {
       if (match) {
         isLocal = /.*[$@?].*/.test(s);
         
-        if (isProperty) {
+        if (operandFunctions.has(match[0].toLowerCase())) {
+          tokenKind = TokenKind.opCode;
+          tokenType = TokenType.keyword;
+          tokenModifiers = TokenModifier.static;
+        } else if (isProperty) {
           tokenKind = TokenKind.property;
           tokenType = TokenType.property;
         } else if (registers.has(match[0].toLowerCase())) {

--- a/src/providers/hover.ts
+++ b/src/providers/hover.ts
@@ -89,6 +89,19 @@ export class HoverProvider implements vscode.HoverProvider {
 
             return new vscode.Hover(help, assemblyLine.opCodeRange);
           }
+
+          const func = this.workspaceManager.docs.getFunction(type?.text);
+          if (type && func) {
+            const help = new vscode.MarkdownString();
+
+            help.appendCodeblock(`(function) ${type.text}`);
+
+            if (func.summary) {
+              help.appendMarkdown('---\n' + func.summary);
+            }
+
+            return new vscode.Hover(help, assemblyLine.typeRange);
+          }
           return;
         }
 

--- a/src/test/parsers/docs.spec.ts
+++ b/src/test/parsers/docs.spec.ts
@@ -37,6 +37,23 @@ describe('Docs', () => {
       const opcode = docs.getOpcode(undefined);
       expect(opcode).toBeFalsy();
     });
+
+    it("should not get a function that doesn't exist", () => {
+      const func = docs.getFunction('SIZE');
+      expect(func).toBeFalsy();
+    });
+
+    it("should not get a function from undefined", () => {
+      const func = docs.getFunction(undefined);
+      expect(func).toBeFalsy();
+    });
+
+    it("should get a function that does exist", () => {
+      const func = docs.getFunction('SIZEOF');
+      expect(func).toBeTruthy();
+      expect(func?.name).toBe('SIZEOF');
+      expect(func?.summary).toBe('Set a Symbol to a Value');
+    });
   });
 
   describe('find docs', () => {
@@ -62,6 +79,12 @@ describe('Docs', () => {
     it('should not find opcodes starting with L', () => {
       const opcodes = docs.findOpcode('L');
       expect(opcodes.length).toBe(0);
+    });
+
+    it('should find functions that start with S', () => {
+      const functions = docs.findFunction('S');
+      expect(functions.length).toBe(1);
+      expect(functions[0].name).toBe('SIZEOF');
     });
   });
 

--- a/src/test/parsers/line-parser.spec.ts
+++ b/src/test/parsers/line-parser.spec.ts
@@ -1365,6 +1365,62 @@ describe('LineParser', () => {
       expect(tokens[1]).toEqual(expectedAllOperandToken);
       expect(tokens[2]).toEqual(expectedOperandToken);
     });
+    
+    it(`sizeof operand returns opcode, operand tokens`, () => {
+      const expectedOpcode = opcode;
+      const expectedFunction = 'sizeof';
+      const expectedVariable = 'this';
+      const expectedOperand = `${expectedFunction}{${expectedVariable}}`;
+      const line = ` ${expectedOpcode} ${expectedOperand}`;
+      const expectedOpcodeToken = new Token(
+        expectedOpcode,
+        line.indexOf(expectedOpcode),
+        expectedOpcode.length,
+        TokenKind.opCode,
+        TokenType.keyword);
+      const expectedAllOperandToken = new Token(
+        expectedOperand,
+        line.indexOf(expectedOperand),
+        expectedOperand.length,
+        TokenKind.operand,
+        TokenType.namespace);
+      const expectedFunctionToken = new Token(
+        expectedFunction,
+        line.indexOf(expectedFunction),
+        expectedFunction.length,
+        TokenKind.opCode,
+        TokenType.keyword);
+      expectedFunctionToken.modifiers = TokenModifier.static;
+      const expectedOpenOperator = new Token(
+        '{',
+        line.indexOf('{'),
+        1,
+        TokenKind.ignore,
+        TokenType.operator);
+      const expectedVariableToken = new Token(
+        expectedVariable,
+        line.indexOf(expectedVariable),
+        expectedVariable.length,
+        TokenKind.reference,
+        TokenType.variable);
+      const expectedCloseOperator = new Token(
+        '}',
+        line.indexOf('}'),
+        1,
+        TokenKind.ignore,
+        TokenType.operator);
+
+      const tokens = LineParser.parse(line);
+
+      expect(tokens.length).toBe(6);
+      expect(tokens[0]).toEqual(expectedOpcodeToken);
+      expect(tokens[1]).toEqual(expectedAllOperandToken);
+      expect(tokens[2]).toEqual(expectedFunctionToken);
+      expect(tokens[3]).toEqual(expectedOpenOperator);
+      expect(tokens[4]).toEqual(expectedVariableToken);
+      expect(tokens[5]).toEqual(expectedCloseOperator);
+    });
+
   });
 
   ['fcc', 'fcn', 'fcs'].forEach(pseudo => {

--- a/src/test/scaffold.ts
+++ b/src/test/scaffold.ts
@@ -40,6 +40,9 @@ export class TextContent {
       'Name\tSummary\n' +
       'EQU\tSet a Symbol to a Value\n' +
       'FCB\tDefine Byte(s)\n'],
+    ['valid-docs-functions.tsv',
+      'Name\tSummary\n' +
+      'SIZEOF\tSet a Symbol to a Value\n'],
     ['valid-hello.asm',
       '  org $1000\n' +
       'start\n' +


### PR DESCRIPTION
**Thank you for your contribution to the vscode-6x09-assembly repo.**

This PR is a:
- [x] Bugfix (`fix/` branch)
- [ ] Feature (`feature/` branch)
- [ ] Refactoring, no functional changes (`refactor/` branch)
- [ ] Other (please describe): <!-- Please describe the type of PR -->


Before submitting this PR, please make sure:
- [x] I created issue #141
- [x] I have read and understood the Code of Conduct and the Contributing Guidelines
- [x] My code builds clean without any errors or warnings
- [x] I followed the style of the existing code
- [x] I added unit tests with appropriate code converage and all unit tests pass

## Description

Added support for sizeof{}
